### PR TITLE
Rework WC cluster based on Specs

### DIFF
--- a/packages/matter.js/src/cluster/WindowCoveringCluster.ts
+++ b/packages/matter.js/src/cluster/WindowCoveringCluster.ts
@@ -4,94 +4,19 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { TlvEnum, TlvUInt16 } from "../tlv/TlvNumber.js";
-import { TlvObject, TlvOptionalField } from "../tlv/TlvObject.js";
-import { Attribute, ClusterExtend, Command, OptionalCommand, TlvNoResponse } from "./Cluster.js";
+import { TlvEnum } from "../tlv/TlvNumber.js";
+import { ClusterExtend, Command, FixedAttribute, OptionalCommand, TlvNoResponse } from "./Cluster.js";
 import { ClusterServerObjForCluster } from "./server/ClusterServer.js";
-import { WindowCoveringClusterSchema } from "./schema/WindowCovering.js";
-import { MatterApplicationClusterSpecificationV1_0 } from "../spec/Specifications.js";
-
-/** alias for percentages expressed as 0 to 100.00 with 2 decimals */
-const WCPercent100ths = TlvUInt16.bound({ max: 10000 });
-
-/** @see {@link MatterApplicationClusterSpecificationV1_0} § 5.3.5.1 */
-export enum WindowCoveringType {
-    /** Lift Only */
-    RollerShade = 0x00,
-
-    /** Lift Only */
-    RollerShade2Motor = 0x01,
-
-    /** Lift Only */
-    RollerShadeExterior = 0x02,
-
-    /** Lift Only */
-    RollerShadeExterior2Motor = 0x03,
-
-    /** Lift Only */
-    Drapery = 0x04,
-
-    /** Lift Only */
-    Awning = 0x05,
-
-    /** Lift & Tilt */
-    Shutter = 0x06,
-
-    /** Tilt Only */
-    TiltOnlyBlind = 0x07,
-
-    /** Lift & Tilt */
-    LiftAndTiltBlind = 0x08,
-
-    /** Lift Only */
-    ProjectorScreen = 0x09,
-
-    Unknown = 0xff,
-}
-
-/** @see {@link MatterApplicationClusterSpecificationV1_0} § 5.3.5.15 */
-export enum WindowCoveringOperationalStatus {
-    Stopped = 0,
-    Opening = 1,
-    Closing = 2,
-}
-
-/** @see {@link MatterApplicationClusterSpecificationV1_0} § 5.3.6.5
- - If the command includes LiftPercent100thsValue, then TargetPositionLiftPercent100ths attribute SHALL be set to
-   LiftPercent100thsValue. Otherwise the TargetPositionLiftPercent100ths attribute SHALL be set to
-   LiftPercentageValue * 100.
- - If a client includes LiftPercent100thsValue in the command, the LiftPercentageValue SHALL be set to
-   LiftPercent100thsValue / 100, so a legacy server which only supports LiftPercentageValue (not LiftPercent100thsValue)
-   has a value to set the target position.
- - If the server does not support the Position Aware feature, then a zero percentage SHALL be treated as a
-   UpOrOpen command and a non-zero percentage SHALL be treated as an DownOrClose command.
-   If the device is only a tilt control device, then the command SHOULD be ignored and a UNSUPPORTED_COMMAND status
-   SHOULD be returned.
- */
-export const GotoLiftPercentParams = TlvObject({
-    /** Legacy Matter - still used by HomePod 16.3.2*/
-    percent: TlvOptionalField(0, WCPercent100ths), // TODO - clarify if this is correct and needs to be handled in WC Server
-    /** PREFERRED  */
-    percent100ths: TlvOptionalField(1, WCPercent100ths),
-});
-
-/** @see {@link MatterApplicationClusterSpecificationV1_0} § 5.3.6.7 */
-const GotoTiltPercentParams = GotoLiftPercentParams;
+import {
+    TlvGoToLiftPercentRequest, TlvGoToLiftValueRequest, TlvGoToTiltPercentRequest, WindowCoveringClusterSchema,
+    WindowCoveringType
+} from "./schema/WindowCovering.js";
 
 // For now use the Schema cluster as basis for the cluster object temporary
 export const WindowCoveringCluster = WindowCoveringClusterSchema;
 
 ////////////////////////////////// MIGHT GO AWAY
 
-const statusAttribute = {
-    operationalStatus: Attribute(
-        0x000a,
-        TlvEnum<WindowCoveringOperationalStatus>(),
-        {
-            default: WindowCoveringOperationalStatus.Stopped,
-        }
-    ),
-};
 
 /** PositionAwareLift */
 export const WCPositionAwareLiftCluster = ClusterExtend(WindowCoveringCluster, {
@@ -103,14 +28,13 @@ export const WCPositionAwareLiftCluster = ClusterExtend(WindowCoveringCluster, {
         absolutePosition: false,
     },
     commands: {
-        gotoLiftPercent: Command(0x05, GotoLiftPercentParams, 5, TlvNoResponse),
+        gotoLiftPercent: Command(0x05, TlvGoToLiftPercentRequest, 5, TlvNoResponse),
     },
     attributes: {
-        type: Attribute(0x0000, TlvEnum<WindowCoveringType>(), {
+        type: FixedAttribute(0x0000, TlvEnum<WindowCoveringType>(), {
             default: WindowCoveringType.RollerShade,
             persistent: true,
         }),
-        ...statusAttribute,
     },
 });
 
@@ -124,14 +48,13 @@ export const WCPositionAwareTiltCluster = ClusterExtend(WindowCoveringCluster, {
         absolutePosition: false,
     },
     commands: {
-        gotoTiltPercent: Command(0x08, GotoTiltPercentParams, 8, TlvNoResponse),
+        gotoTiltPercent: Command(0x08, TlvGoToLiftValueRequest, 8, TlvNoResponse),
     },
     attributes: {
-        type: Attribute(0x0000, TlvEnum<WindowCoveringType>(), {
-            default: WindowCoveringType.TiltOnlyBlind,
+        type: FixedAttribute(0x0000, TlvEnum<WindowCoveringType>(), {
+            default: WindowCoveringType.TiltBlindTiltOnly,
             persistent: true,
         }),
-        ...statusAttribute,
     },
 });
 
@@ -149,21 +72,20 @@ export const WCPositionAwareLiftAndTiltCluster = ClusterExtend(
         commands: {
             gotoLiftPercent: OptionalCommand(
                 0x05,
-                GotoLiftPercentParams,
+                TlvGoToLiftPercentRequest,
                 5,
                 TlvNoResponse
             ),
             gotoTiltPercent: OptionalCommand(
                 0x08,
-                GotoTiltPercentParams,
+                TlvGoToTiltPercentRequest,
                 8,
                 TlvNoResponse
             ),
         },
         attributes: {
-            ...statusAttribute,
-            type: Attribute(0x0000, TlvEnum<WindowCoveringType>(), {
-                default: WindowCoveringType.LiftAndTiltBlind,
+            type: FixedAttribute(0x0000, TlvEnum<WindowCoveringType>(), {
+                default: WindowCoveringType.TiltBlindLiftAndTilt,
                 persistent: true,
             }),
         },

--- a/packages/matter.js/src/protocol/interaction/InteractionServer.ts
+++ b/packages/matter.js/src/protocol/interaction/InteractionServer.ts
@@ -275,7 +275,7 @@ export function ClusterServer<F extends BitSchema, SF extends TypeFromPartialBit
             if (mandatoryIf !== undefined && mandatoryIf.length > 0) {
                 const conditionMatched = isConditionMatching(mandatoryIf, fullyQualifiedSupportedFeatures);
                 if (conditionMatched && handler === undefined) {
-                    logger.warn(`Command "${clusterDef.name}/${name}" is REQUIRED by supportedFeatures:${JSON.stringify(fullyQualifiedSupportedFeatures)} but is not set!`);
+                    logger.warn(`Command "${clusterDef.name}/${name}" is REQUIRED by supportedFeatures: ${JSON.stringify(fullyQualifiedSupportedFeatures)} but is not set!`);
                 }
                 conditionHasMatched = conditionHasMatched || conditionMatched;
             }
@@ -283,7 +283,7 @@ export function ClusterServer<F extends BitSchema, SF extends TypeFromPartialBit
             if (optionalIf !== undefined) {
                 const conditionMatched = isConditionMatching(optionalIf, fullyQualifiedSupportedFeatures);
                 if (conditionMatched && handler === undefined) {
-                    logger.debug(`Command "${clusterDef.name}/${name}" is optional by supportedFeatures:${JSON.stringify(fullyQualifiedSupportedFeatures)} and is not set!`);
+                    logger.debug(`Command "${clusterDef.name}/${name}" is optional by supportedFeatures: ${JSON.stringify(fullyQualifiedSupportedFeatures)} and is not set!`);
                 }
                 conditionHasMatched = conditionHasMatched || conditionMatched;
             }
@@ -321,7 +321,7 @@ export function ClusterServer<F extends BitSchema, SF extends TypeFromPartialBit
             if (mandatoryIf !== undefined) {
                 const conditionMatched = isConditionMatching(mandatoryIf, fullyQualifiedSupportedFeatures);
                 if (conditionMatched && (supportedEvents as any)[eventName] === undefined) {
-                    logger.warn(`Event "${clusterDef.name}/${eventName}" is REQUIRED by supportedFeatures:${JSON.stringify(fullyQualifiedSupportedFeatures)} but is not set!`);
+                    logger.warn(`Event "${clusterDef.name}/${eventName}" is REQUIRED by supportedFeatures: ${JSON.stringify(fullyQualifiedSupportedFeatures)} but is not set!`);
                 }
                 conditionHasMatched = conditionHasMatched || conditionMatched;
             }
@@ -329,7 +329,7 @@ export function ClusterServer<F extends BitSchema, SF extends TypeFromPartialBit
             if (optionalIf !== undefined) {
                 const conditionMatched = isConditionMatching(optionalIf, fullyQualifiedSupportedFeatures);
                 if (conditionMatched && (supportedEvents as any)[eventName] === undefined) {
-                    logger.debug(`Event "${clusterDef.name}/${eventName}" is optional by supportedFeatures:${JSON.stringify(fullyQualifiedSupportedFeatures)} and is not set!`);
+                    logger.debug(`Event "${clusterDef.name}/${eventName}" is optional by supportedFeatures: ${JSON.stringify(fullyQualifiedSupportedFeatures)} and is not set!`);
                 }
                 conditionHasMatched = conditionHasMatched || conditionMatched;
             }

--- a/packages/matter.js/src/tlv/TlvNumber.ts
+++ b/packages/matter.js/src/tlv/TlvNumber.ts
@@ -3,7 +3,7 @@
  * Copyright 2022-2023 Project CHIP Authors
  * SPDX-License-Identifier: Apache-2.0
  */
-import { BitmapSchema, BitSchema, TypeFromBitSchema } from "../schema/BitmapSchema.js";
+import { BitmapSchema, BitSchema, TypeFromPartialBitSchema } from "../schema/BitmapSchema.js";
 import {
     FLOAT32_MAX, FLOAT32_MIN, INT16_MAX, INT16_MIN, INT32_MAX, INT32_MIN, INT64_MAX, INT64_MIN, INT8_MAX, INT8_MIN,
     maxValue, minValue, UINT16_MAX, UINT32_MAX, UINT64_MAX, UINT8_MAX
@@ -107,5 +107,18 @@ export const TlvUInt64 = new TlvLongNumberSchema(TlvType.UnsignedInt, value => T
 export const TlvEnum = <T>() => TlvUInt32 as TlvSchema<number> as TlvSchema<T>;
 export const TlvBitmap = <T extends BitSchema>(underlyingSchema: TlvNumberSchema, bitSchema: T) => {
     const bitmapSchema = BitmapSchema(bitSchema);
-    return new TlvWrapper(underlyingSchema, (bitmapData: TypeFromBitSchema<T>) => bitmapSchema.encode(bitmapData), value => bitmapSchema.decode(value));
+    return new TlvWrapper(underlyingSchema, (bitmapData: TypeFromPartialBitSchema<T>) => bitmapSchema.encode(bitmapData), value => bitmapSchema.decode(value));
 };
+
+// Relative Number types
+export const TlvPercent = TlvUInt8.bound({ max: 100 });
+export const TlvPercent100ths = TlvUInt16.bound({ max: 10000 });
+
+// Time Number types
+export const TlvEpochUs = TlvUInt64;
+export const TlvEpochS = TlvUInt32;
+export const TlvPosixMs = TlvUInt64;
+export const TlvSysTimeUs = TlvUInt64;
+export const TlvSysTimeMS = TlvUInt64;
+
+

--- a/packages/matter.js/test/cluster/ClusterServerTest.ts
+++ b/packages/matter.js/test/cluster/ClusterServerTest.ts
@@ -523,7 +523,7 @@ describe("ClusterServer structure", () => {
                         maintenanceMode: false,
                         ledFeedback: false,
                     },
-                    numOfActuationsLift: 0,
+                    numberOfActuationsLift: 0,
                     targetPositionLiftPercent100ths: 0,
                     currentPositionLiftPercent100ths: 0,
                     installedOpenLimitLift: 0,

--- a/packages/matter.js/test/cluster/ClusterServerTest.ts
+++ b/packages/matter.js/test/cluster/ClusterServerTest.ts
@@ -21,9 +21,9 @@ import { VendorId } from "../../src/datatype/index.js";
 import { DeviceTypes, Endpoint } from "../../src/device/index.js";
 import { Fabric } from "../../src/fabric/index.js";
 import {
-    WindowCoveringClusterSchema, WindowCoveringEndProductType, WindowCoveringOperationalStatus
+    WindowCoveringClusterSchema, WindowCoveringEndProductType, WindowCoveringOperationalStatusEnum,
+    WindowCoveringType
 } from "../../src/cluster/schema/WindowCovering.js";
-import { WindowCoveringType } from "../../src/cluster/WindowCoveringCluster.js";
 import { Level, Logger } from "../../src/log/index.js";
 
 describe("ClusterServer structure", () => {
@@ -506,16 +506,20 @@ describe("ClusterServer structure", () => {
                     configStatus: {
                         liftPositionAware: false,
                         operational: false,
-                        liftPositionType: false,
-                        reversed: false,
+                        liftEncoderControlled: false,
+                        liftMovementReversed: false,
                         tiltPositionAware: false,
-                        tiltPositionType: false,
+                        tiltEncoderControlled: false,
                     },
-                    operationalStatus: WindowCoveringOperationalStatus.Stopped,
+                    operationalStatus: {
+                        coveringStatus: WindowCoveringOperationalStatusEnum.Stopped,
+                        liftStatus: WindowCoveringOperationalStatusEnum.Stopped,
+                        tiltStatus: WindowCoveringOperationalStatusEnum.Stopped,
+                    },
                     endProductType: WindowCoveringEndProductType.RollerShade,
                     mode: {
-                        reversed: false,
-                        calibrateMode: false,
+                        motorDirectionReversed: false,
+                        calibrationMode: false,
                         maintenanceMode: false,
                         ledFeedback: false,
                     },
@@ -526,9 +530,9 @@ describe("ClusterServer structure", () => {
                     currentPositionTiltPercent100ths: 0, // Should not be there because not valid for feature-combination
                 },
                 {
-                    open: async () => { /* dummy */ },
-                    close: async () => { /* dummy */ },
-                    stop: async () => { /* dummy */ }
+                    upOrOpen: async () => { /* dummy */ },
+                    downOrClose: async () => { /* dummy */ },
+                    stopMotion: async () => { /* dummy */ }
                     // gotoLiftValue: async () => { /* dummy */ }, // Should be existing but not set
                 }
             );
@@ -536,12 +540,12 @@ describe("ClusterServer structure", () => {
             // TODO: Find out how to set TZ=UTC when executing single tests locally
 
             assert.deepEqual(fakeLogSink, [
-                { level: Level.DEBUG, log: '1970-01-01 00:00:00.000 DEBUG InteractionProtocol InitialAttributeValue for "Window Covering/physicalClosedLimitLift" is optional by supportedFeatures: {"lift":true,"tilt":false,"positionAwareLift":true,"absolutePosition":false,"positionAwareTilt":false} and is not set!' },
-                { level: Level.DEBUG, log: '1970-01-01 00:00:00.000 DEBUG InteractionProtocol InitialAttributeValue for "Window Covering/currentPositionLift" is optional by supportedFeatures: {"lift":true,"tilt":false,"positionAwareLift":true,"absolutePosition":false,"positionAwareTilt":false} and is not set!' },
-                { level: Level.DEBUG, log: '1970-01-01 00:00:00.000 DEBUG InteractionProtocol InitialAttributeValue for "Window Covering/currentPositionLiftPercent" is optional by supportedFeatures: {"lift":true,"tilt":false,"positionAwareLift":true,"absolutePosition":false,"positionAwareTilt":false} and is not set!' },
-                { level: Level.WARN, log: '1970-01-01 00:00:00.000 WARN InteractionProtocol InitialAttributeValue for "Window Covering/currentPositionTiltPercent100ths" is provided but it\'s neither optional or mandatory for supportedFeatures: {"lift":true,"tilt":false,"positionAwareLift":true,"absolutePosition":false,"positionAwareTilt":false} but is set!' },
-                { level: Level.WARN, log: '1970-01-01 00:00:00.000 WARN InteractionProtocol InitialAttributeValue for "Window Covering/installedClosedLimitLift" is REQUIRED by supportedFeatures: {"lift":true,"tilt":false,"positionAwareLift":true,"absolutePosition":false,"positionAwareTilt":false} but is not set!' },
-                { level: Level.WARN, log: '1970-01-01 00:00:00.000 WARN InteractionProtocol Command "Window Covering/gotoLiftPercent" is REQUIRED by supportedFeatures:{"lift":true,"tilt":false,"positionAwareLift":true,"absolutePosition":false,"positionAwareTilt":false} but is not set!' }
+                { level: Level.DEBUG, log: '1970-01-01 00:00:00.000 DEBUG InteractionProtocol InitialAttributeValue for "WindowCovering/physicalClosedLimitLift" is optional by supportedFeatures: {"lift":true,"tilt":false,"positionAwareLift":true,"absolutePosition":false,"positionAwareTilt":false} and is not set!' },
+                { level: Level.DEBUG, log: '1970-01-01 00:00:00.000 DEBUG InteractionProtocol InitialAttributeValue for "WindowCovering/currentPositionLift" is optional by supportedFeatures: {"lift":true,"tilt":false,"positionAwareLift":true,"absolutePosition":false,"positionAwareTilt":false} and is not set!' },
+                { level: Level.DEBUG, log: '1970-01-01 00:00:00.000 DEBUG InteractionProtocol InitialAttributeValue for "WindowCovering/currentPositionLiftPercentage" is optional by supportedFeatures: {"lift":true,"tilt":false,"positionAwareLift":true,"absolutePosition":false,"positionAwareTilt":false} and is not set!' },
+                { level: Level.WARN, log: '1970-01-01 00:00:00.000 WARN InteractionProtocol InitialAttributeValue for "WindowCovering/currentPositionTiltPercent100ths" is provided but it\'s neither optional or mandatory for supportedFeatures: {"lift":true,"tilt":false,"positionAwareLift":true,"absolutePosition":false,"positionAwareTilt":false} but is set!' },
+                { level: Level.WARN, log: '1970-01-01 00:00:00.000 WARN InteractionProtocol InitialAttributeValue for "WindowCovering/installedClosedLimitLift" is REQUIRED by supportedFeatures: {"lift":true,"tilt":false,"positionAwareLift":true,"absolutePosition":false,"positionAwareTilt":false} but is not set!' },
+                { level: Level.WARN, log: '1970-01-01 00:00:00.000 WARN InteractionProtocol Command "WindowCovering/goToLiftPercent" is REQUIRED by supportedFeatures: {"lift":true,"tilt":false,"positionAwareLift":true,"absolutePosition":false,"positionAwareTilt":false} but is not set!' }
             ]);
         });
     });


### PR DESCRIPTION
This "Internal PR" reworks the Widnow covering cluster based on Specs and XMLs

It does nrenaming to be near to specs in most places and sets correct types and such

For review ideally focus on the Schema/WindowCovering.ts file

@vves mentioned that Apple migth not have implemented anything correctly, what was that?