### PR TITLE
Tweaks for testing extensible cluster

### DIFF
--- a/packages/matter-node.js-examples/src/examples/DeviceNode.ts
+++ b/packages/matter-node.js-examples/src/examples/DeviceNode.ts
@@ -26,7 +26,7 @@ import { StorageManager, StorageBackendDisk } from "@project-chip/matter-node.js
 import { Ble } from "@project-chip/matter-node.js/ble";
 import { BleNode } from "@project-chip/matter-node-ble.js/ble";
 import {
-    WifiNetworkCommissioningCluster, NetworkCommissioningStatus, ClusterServerHandlers, GeneralCommissioningCluster
+    NetworkCommissioningStatus, ClusterServerHandlers, GeneralCommissioningCluster, NetworkCommissioning
 } from "@project-chip/matter-node.js/cluster";
 import { ClusterServer } from "@project-chip/matter-node.js/interaction";
 
@@ -166,8 +166,9 @@ class Device {
             // the device implementor based on the relevant networking stack.
             // The NetworkCommissioningCluster and all logics are described in Matter Core Specifications section 11.8
             const firstNetworkId = new ByteArray(32);
+            const Cluster = NetworkCommissioning.Cluster.with("WiFiNetworkInterface");
             commissioningServer.addRootClusterServer(ClusterServer(
-                WifiNetworkCommissioningCluster,
+                Cluster,
                 {
                     maxNetworks: 1,
                     interfaceEnabled: true,
@@ -318,7 +319,7 @@ class Device {
                             networkIndex: 0
                         };
                     },
-                } as ClusterServerHandlers<typeof WifiNetworkCommissioningCluster>
+                } as ClusterServerHandlers<typeof Cluster>
             ));
         }
 

--- a/packages/matter.js/src/cluster/index.ts
+++ b/packages/matter.js/src/cluster/index.ts
@@ -7,6 +7,7 @@
 // Export general Cluster specific types
 export * from "./Cluster.js";
 export * from "./ClusterHelper.js";
+export { NetworkCommissioning } from "./definitions/index.js";
 
 // Export all Cluster definitions
 export * from "./AccessControlCluster.js";


### PR DESCRIPTION
Hey so here I did the bare minimum to pull in the new NetworkCommissioningCluster for use in DeviceNode.  I just replaced the one cluster we've been talking about (WifiNetworkCommissioningCluster) and it seems to work.  I didn't merge in main because I wanted to see the two side-by-side, so it's possible something additional is broken with more recent changes.